### PR TITLE
Fix mock's version spec

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@
 
 coverage
 django-nose
-mock=>1.0,<1.1
+mock>=1.0,<1.1
 nose
 transifex-client
 flake8


### PR DESCRIPTION
Fixes `Invalid requirement: 'mock=>1.0,<1.1'` when running `pip install -r requirements-dev.txt`.