### PR TITLE
Promote PBF as a top-level export format

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -377,6 +377,7 @@ class JobSerializer(serializers.Serializer):
     additional export formats.
     """
     EXPORT_FORMAT_CHOICES = (
+        ('pbf', 'OSM PBF'),
         ('shp', 'Shapefile Format'),
         ('obf', 'OBF Format'),
         ('kml', 'KML Format'),

--- a/core/settings/project.py
+++ b/core/settings/project.py
@@ -12,10 +12,10 @@ INSTALLED_APPS += (
     'utils',
 )
 
-
 LOGIN_URL = '/login/'
 
 EXPORT_TASKS = {
+    'pbf': 'tasks.export_tasks.PbfExportTask',
     'shp': 'tasks.export_tasks.ShpExportTask',
     'obf': 'tasks.export_tasks.ObfExportTask',
     'sqlite': 'tasks.export_tasks.SqliteExportTask',

--- a/jobs/migrations/0028_promote_pbf_export_format.py
+++ b/jobs/migrations/0028_promote_pbf_export_format.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from ..models import ExportFormat
+
+
+class Migration(migrations.Migration):
+
+    def promote_pbf_export_format(apps, schema_editor):
+        ExportFormat = apps.get_model('jobs', 'ExportFormat')
+        ExportFormat.objects.create(name='PBF Format', description='OSM PBF',
+                                    slug='PBF')
+
+    dependencies = [
+        ('jobs', '0003_auto_20151027_1807'),
+    ]
+
+    operations = [
+        migrations.RunPython(promote_pbf_export_format),
+    ]

--- a/tasks/export_tasks.py
+++ b/tasks/export_tasks.py
@@ -213,6 +213,19 @@ class OSMPrepSchemaTask(ExportTask):
         return {'result': sqlite}
 
 
+class PbfExportTask(ExportTask):
+    """
+    Class defining PBF export function.
+    """
+    name = 'PBF Export'
+
+    def run(self, run_uid=None, stage_dir=None, job_name=None):
+        self.update_task_state(run_uid=run_uid, name=self.name)
+        pbffile = stage_dir + job_name + '.pbf'
+        # output already exists
+        return {'result': pbffile}
+
+
 class ThematicLayersExportTask(ExportTask):
     """
     Task to export thematic shapefile.

--- a/tasks/export_tasks.py
+++ b/tasks/export_tasks.py
@@ -187,8 +187,8 @@ class OSMToPBFConvertTask(ExportTask):
 
     def run(self, run_uid=None, stage_dir=None, job_name=None):
         self.update_task_state(run_uid=run_uid, name=self.name)
-        osm = stage_dir + job_name + '.osm'
-        pbffile = stage_dir + job_name + '.pbf'
+        osm = '{0}{1}.osm'.format(stage_dir, job_name)
+        pbffile = '{0}{1}.pbf'.format(stage_dir, job_name)
         o2p = pbf.OSMToPBF(osm=osm, pbffile=pbffile)
         pbffile = o2p.convert()
         return {'result': pbffile}
@@ -215,14 +215,17 @@ class OSMPrepSchemaTask(ExportTask):
 
 class PbfExportTask(ExportTask):
     """
-    Class defining PBF export function.
+    Convert unfiltered Overpass output to PBF.
+    Returns the path to the PBF file.
     """
     name = 'PBF Export'
 
     def run(self, run_uid=None, stage_dir=None, job_name=None):
         self.update_task_state(run_uid=run_uid, name=self.name)
-        pbffile = stage_dir + job_name + '.pbf'
-        # output already exists
+        osm = '{0}query.osm'.format(stage_dir)
+        pbffile = '{0}{1}-full.pbf'.format(stage_dir, job_name)
+        o2p = pbf.OSMToPBF(osm=osm, pbffile=pbffile)
+        pbffile = o2p.convert()
         return {'result': pbffile}
 
 

--- a/ui/static/ui/js/clone.js
+++ b/ui/static/ui/js/clone.js
@@ -464,7 +464,7 @@ clone.job = (function(){
                     validators: {
                         choice: {
                             min: 1,
-                            max: 6,
+                            max: 7,
                             message: gettext('At least one export format must be selected')
                         }
                     }

--- a/ui/static/ui/js/create.js
+++ b/ui/static/ui/js/create.js
@@ -466,7 +466,7 @@ create.job = (function(){
                     validators: {
                         choice: {
                             min: 1,
-                            max: 6,
+                            max: 7,
                             message: gettext('At least one export format must be selected')
                         }
                     }

--- a/utils/overpass.py
+++ b/utils/overpass.py
@@ -51,7 +51,7 @@ class Overpass(object):
 
         # extract all nodes / ways and relations within the bounding box
         # see: http://wiki.openstreetmap.org/wiki/Overpass_API/Overpass_QL
-        self.default_template = Template('[maxsize:$maxsize][timeout:$timeout];(node($bbox);<;);out body;')
+        self.default_template = Template('[maxsize:$maxsize][timeout:$timeout];(node($bbox);<;>>;>;);out meta;')
 
         # see http://wiki.openstreetmap.org/wiki/Osmfilter#Object_Filter
         self.filter_template = '--keep={0}'.format(' or '.join(self.filters))


### PR DESCRIPTION
This modifies the Overpass query to fetch metadata and dependent entities (outside the desired bounding box) in order to make it suitable for importing into an APIDB schema.

As the PBF is often useful enough on its own, it deserves to be a top-level format. This also achieves that.
