### PR TITLE
docs: fix outdated content in help documentation pages (#506)

### DIFF
--- a/ui/app/components/help/API.js
+++ b/ui/app/components/help/API.js
@@ -24,7 +24,7 @@ export default () =>
             <div>
               <h2 id="overview">Overview</h2>
               <p>
-                The Export Tool has an API that can be called programatically via the web. 
+                The Export Tool has an API that can be called programmatically via the web.
                 For example, you can automatically schedule an export to be run weekly to accompany a humanitarian mapping project.
               </p>
             </div>
@@ -72,7 +72,7 @@ export default () =>
               <p>
                 This is an incomplete list of API endpoints. For more information,
                 please consult the{" "}
-                <a href="https://github.com/hotosm/osm-export-tool2/tree/master/api">
+                <a href="https://github.com/hotosm/osm-export-tool/tree/main/api">
                   source code on GitHub
                 </a>{" "}
                 or explore <a href="/api/">the auto-generated API documentation</a>.

--- a/ui/app/components/help/BrowsingExports.js
+++ b/ui/app/components/help/BrowsingExports.js
@@ -60,7 +60,7 @@ export default () =>
               <h2 id="rerunexport">Re-running an Export</h2>
               <img src={rerunClone} style={{width:"50%"}} />
               <p>
-                  “Re-running” an export lets you extract data using the same settings of the area, description, file formats and feature selection.
+                  "Re-running" an export lets you extract data using the same settings of the area, description, file formats and feature selection.
                   This function is generally used to obtain updated OSM data, including any added or modified information since the export was last run.
                   This is important to ensure that the information is current as OSM is constantly changing.
                   You will need to authenticate with an account to re-run an export.
@@ -80,7 +80,7 @@ export default () =>
             <h3>IN THIS AREA</h3>
             <ul>
               <li><a href="#overview">Overview</a></li>
-              <li><a href="#exportlist">Export List</a></li>
+              <li><a href="#exportslist">Exports List</a></li>
               <li><a href="#exportdetails">Export Details</a></li>
               <li><a href="#rerunexport">Re-running an Export</a></li>
               <li><a href="#cloneexport">Cloning an Export</a></li>

--- a/ui/app/components/help/FeatureSelections.js
+++ b/ui/app/components/help/FeatureSelections.js
@@ -101,7 +101,7 @@ export default () =>
               <h2 id="moreresources">More Resources</h2>
               <ul>
                 <li><a href="http://wiki.openstreetmap.org/wiki/Humanitarian_OSM_Tags">OpenStreetMap Wiki - Humanitarian OSM Tags</a></li>
-                <li><a href="http://wiki.openstreetmap.org/wiki/Map_Features">OpenstreetMap Wiki - OSM Tags</a></li>
+                <li><a href="http://wiki.openstreetmap.org/wiki/Map_Features">OpenStreetMap Wiki - OSM Tags</a></li>
               </ul>
             </div>
           </Col>

--- a/ui/app/components/help/Index.js
+++ b/ui/app/components/help/Index.js
@@ -86,7 +86,7 @@ export default () =>
               <h2>
                 <Link to="/learn/api">Export Tool API</Link>
               </h2>
-              <p>Create exports programatically via the JSON API.</p>
+              <p>Create exports programmatically via the JSON API.</p>
               <Link className="btn btn-default" to="/learn/api">
                 View
               </Link>

--- a/ui/app/components/help/QuickStart.js
+++ b/ui/app/components/help/QuickStart.js
@@ -27,7 +27,7 @@ export default () =>
             <div>
               <h2 id="overview">Overview</h2>
               <p>
-                Anyone can create a custom OpenStreetMap epxort with the Export Tool - just register an account. You can register with an OpenStreetMap account from <a href="https://openstreetmap.org">OpenStreetMap.org</a> and a valid email address.
+                Anyone can create a custom OpenStreetMap export with the Export Tool - just register an account. You can register with an OpenStreetMap account from <a href="https://openstreetmap.org">OpenStreetMap.org</a> and a valid email address.
               </p>
             </div>
             <div>
@@ -40,13 +40,10 @@ export default () =>
                 </li>
                 <li>
                   <strong>Bounding Box: </strong> Use the "Box" tool to the right to click and drag a rectangle,
-                  or use the "Current View" tool to match the map's viewport.
+                  or use "Current View" to match the map's viewport.
                 </li>
                 <li>
                   <strong>Draw Polygon:</strong> Draw a freeform polygon. This must be a simple (not multi-) polygon.
-                </li>
-                <li>
-                  <strong>Current View:</strong> Use "Current View" to match the map's viewport.
                 </li>
                 <li>
                   <strong>Upload:</strong> By uploading a GeoJSON polygon in WGS84 (geographic) coordinates.
@@ -60,7 +57,7 @@ export default () =>
               <strong>The bounding box of the area can contain at most 10,000,000 OSM nodes. </strong>
               This limitation means that a 10,000 square kilometer box over a heavily mapped area like Western Europe or North America will likely be rejected,
               but an equal sized box over a sparsely mapped area will be accepted by the Export Tool.
-              If you need larger exports, please <a href="mailto:sysadmin@hotosm.org">Contact Us</a> or use an alternative resource such as downloads from <a href="http://download.geofabrik.de">Geofabrik</a> or <a href="https://mapzen.com/data/metro-extracts/">Mapzen</a>.
+              If you need larger exports, please <a href="mailto:sysadmin@hotosm.org">Contact Us</a> or use an alternative resource such as downloads from <a href="http://download.geofabrik.de">Geofabrik</a>.
               </p>
             </div>
             <div>
@@ -110,7 +107,7 @@ export default () =>
               </p>
               <ul>
                 <li><strong>Submitted: </strong> The export is waiting to be processed. This should be brief, depending on server load.</li>
-                <li><strong>Running: </strong> The export is waiting to be processed. City-sized regions should be a few minutes -
+                <li><strong>Running: </strong> The export is being processed. City-sized regions should be a few minutes -
                 larger regions can take upwards of 20 minutes, depending on the density of OSM data.</li>
                 <li><strong>Completed: </strong> Your export files are available for download. Each export format has a separate download link for its ZIP archive.</li>
               </ul>

--- a/ui/app/components/help/Yaml.js
+++ b/ui/app/components/help/Yaml.js
@@ -65,7 +65,7 @@ export default () =>
                   examples of keys in mappings.
                 </li>
                 <li>
-                  the child elements of <code>select</code> and <code>types</code> are
+                  The child elements of <code>select</code> and <code>types</code> are
                   lists. List elements are preceded by a dash. This dash must have a
                   space after it.
                 </li>
@@ -90,13 +90,13 @@ export default () =>
             <div>
               <h2 id="geometrytypes">Geometry Types</h2>
               <p>
-                the list values under types can be one or more of <code>- points</code>,{" "}
-                <code>- lines</code>, <code>- polygons</code>. if the <code>types</code>{" "}
+                The list values under types can be one or more of <code>- points</code>,{" "}
+                <code>- lines</code>, <code>- polygons</code>. If the <code>types</code>{" "}
                 key is omitted, all 3 geometry types will be included in the theme.
               </p>
             </div>
             <div>
-              <h2 id="columnselections">Column selections</h2>
+              <h2 id="columnselections">Column Selections</h2>
               <p>
                 List items under the <code>select</code> key determine the columns for
                 each theme.
@@ -140,7 +140,7 @@ export default () =>
                 <code>natural</code> has the value <code>waterway</code>. It is almost
                 always necessary to have some kind of filtering, otherwise your theme
                 will simply include all OSM features for the given geometry types. You
-                can specify a filter using SQL-like syntax. valid SQL keywords are{" "}
+                can specify a filter using SQL-like syntax. Valid SQL keywords are{" "}
                 <code>IS NOT NULL, AND, OR, IN, =, !=</code>.
               </p>
               <p>Other examples of filters:</p>


### PR DESCRIPTION
## Summary

Updates the help documentation pages (`ui/app/components/help/`) to fix outdated 
and incorrect content, as requested in #506.

`ExportFormats.js` was intentionally left untouched, as it's covered by #483.

## Changes by file

**QuickStart.js**
- Fix typo: `epxort` → `export`
- Remove duplicate "Current View" AOI option and correct count from "4 ways" 
  (which actually listed 5) to a consistent 4
- Remove dead link to the discontinued Mapzen service
- Fix "Running" status description, which incorrectly repeated the "Submitted" text

**BrowsingExports.js**
- Fix broken TOC anchor link (`#exportlist` → `#exportslist`, didn't match the 
  section's actual `id`)
- Align TOC label with the actual heading text ("Exports List")
- Normalize curly quotes to straight quotes for consistency

**Index.js**
- Fix typo: `programatically` → `programmatically`

**API.js**
- Fix typo: `programatically` → `programmatically`
- Fix broken GitHub link pointing to the old repo name (`osm-export-tool2`) and 
  old default branch (`master`) → updated to `osm-export-tool` / `main`

**FeatureSelections.js**
- Fix inconsistent capitalization: `OpenstreetMap` → `OpenStreetMap`

**Yaml.js**
- Capitalize the start of sentences/list items in a few places
- Fix heading/TOC text inconsistency: "Column selections" → "Column Selections"

## Verification

- Each change was manually verified against current production behavior 
  (export.hotosm.org), current GitHub repo state, or internal code consistency 
  (matching anchors/ids), rather than the outdated references in the original 
  issue (staging site / Google Doc from 2023, both no longer usable).
- Ran `eslint` on all 6 modified files: 0 errors, only pre-existing warnings 
  unrelated to these changes (missing `alt` on `<img>`, unused `Alert` import — 
  neither touched by this PR).
- Could not run the local dev server (`yarn start`) or a full build, since the 
  project's `.nvmrc` pins Node 6 (EOL), which is incompatible with modern Node 
  (fails on removed internals like `http_parser`). Happy to address any issues 
  the CI build surfaces.